### PR TITLE
Fix getWith should always return array.

### DIFF
--- a/src/Traits/ModelTrait.php
+++ b/src/Traits/ModelTrait.php
@@ -83,12 +83,13 @@ trait ModelTrait
 	protected function getWith(): array
 	{
 		// Ensure $this->with is set at all
-		if(empty($this->with)){
+		if (empty($this->with))
+		{
 			$this->with = [];
 		}
 		
 		// Force a single table name into an array
-		if (!is_array($this->with))
+		if (! is_array($this->with))
 		{
 			$this->with = [$this->with];
 		}

--- a/src/Traits/ModelTrait.php
+++ b/src/Traits/ModelTrait.php
@@ -104,7 +104,19 @@ trait ModelTrait
 	 */
 	protected function getWithout(): array
 	{
-		return empty($this->without) ? [] : $this->without;
+		// Ensure $this->without is set at all
+		if (empty($this->without))
+		{
+			$this->without = [];
+		}
+		
+		// Force a single table name into an array
+		if (! is_array($this->without))
+		{
+			$this->without = [$this->without];
+		}
+
+		return $this->without;
 	}
 	
 	/**

--- a/src/Traits/ModelTrait.php
+++ b/src/Traits/ModelTrait.php
@@ -82,7 +82,18 @@ trait ModelTrait
 	 */
 	protected function getWith(): array
 	{
-		return empty($this->with) ? [] : $this->with;
+		// Ensure $this->with is set at all
+		if(empty($this->with)){
+			$this->with = [];
+		}
+		
+		// Force a single table name into an array
+		if (!is_array($this->with))
+		{
+			$this->with = [$this->with];
+		}
+
+		return $this->with;
 	}
 	
 	/**


### PR DESCRIPTION
Not sure about the fist check, I think we could check against `null` instead, but this way the previous behavior is preserved.
Fixes #7.