### PR TITLE
Add function withoutAny.

### DIFF
--- a/src/Traits/ModelTrait.php
+++ b/src/Traits/ModelTrait.php
@@ -76,6 +76,18 @@ trait ModelTrait
 	}
 	
 	/**
+	 * Temporarily blocks all tables from being loaded as relations with the next finder.
+	 *
+	 * @return $this
+	 */
+	public function withoutAll()
+	{
+		$this->tmpWithout = array_merge($this->getWithout(), $this->getWith());
+		
+		return $this;
+	}
+	
+	/**
 	 * Return $with
 	 *
 	 * @return array

--- a/src/Traits/ModelTrait.php
+++ b/src/Traits/ModelTrait.php
@@ -80,7 +80,7 @@ trait ModelTrait
 	 *
 	 * @return $this
 	 */
-	public function withoutAll()
+	public function withoutAny()
 	{
 		$this->tmpWithout = array_merge($this->getWithout(), $this->getWith());
 		


### PR DESCRIPTION
Adds a function `withoutAny` to the ModelTrait.

This might be particularily useful when using an `Entity` with the `Model->save()` method.
The function disables loading of all relation tables in this case. Otherwise, relations defined in the Model (`$with = 'xxx';`) will be loaded to the Entity that is being updated and will make `hasChanged()` return true even if no changes are submitted.

Not really confident with the implementation. I guess setting`tmpWith = null;` would do the same.
The functionality could also be realized by allowing `$tables` to be `null` in `without($tabes)` and then handling it there.