### PR TITLE
Allow null attribute values

### DIFF
--- a/src/Traits/EntityTrait.php
+++ b/src/Traits/EntityTrait.php
@@ -16,7 +16,7 @@ trait EntityTrait
 		// First check the framework's version
 		$result = parent::__get($key);
 		
-		if ($result !== null)
+		if ($result !== null || array_key_exists($key, $this->attributes))
 		{
 			return $result;
 		}

--- a/tests/entity/MagicTest.php
+++ b/tests/entity/MagicTest.php
@@ -23,6 +23,18 @@ class MagicTest extends DatabaseTestCase
 	{
         $this->assertNull($this->factory->racecars);
 	}
+
+	public function testGetRespectsNull()
+	{
+		$machine = new Machine([
+			'factory_id' => 1,
+			'factory' => null,
+		]);
+
+		$result = $machine->factory;
+
+        $this->assertNull($result);
+	}
 	
 	public function testRequiresProperties()
 	{


### PR DESCRIPTION
Fixes a bug where an Entity could have an existing attribute with value `null`, yet `Relations` would try to look it up as a table reference.