### PR TITLE
make sure magic calls on entity find the correct table name

### DIFF
--- a/src/Traits/EntityTrait.php
+++ b/src/Traits/EntityTrait.php
@@ -107,8 +107,7 @@ trait EntityTrait
         }
 
         // Format target as a valid table reference
-        // WIP - needs to handle underscores, maybe others?
-        $target = lcfirst(plural($target));
+        $target = strtolower(preg_replace('/(?<!^)[A-Z]+/', '_$0', plural($target)));
 
         // Flatten the arguments to just the keys
         $keys = reset($arguments);


### PR DESCRIPTION
I had two tables called `pages` and `page_contents`.

Beforehand when calling for example `$page->hasPageContents()` on a Page Entity then the library looks for the database wrong table `pageContents` because `__call` doesn't translate the method name from camelCase to snake_case.

This commit fixes this that the snake-case table names such as `page_contents` get found.