### PR TITLE
Fix not compatable with base model in ci 4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "tatter/schemas": "^2.0"
     },
     "require-dev": {
-        "codeigniter4/framework": "^4.1",
+        "codeigniter4/framework": "^4.5",
         "tatter/tools": "^2.0"
     },
     "minimum-stability": "dev",

--- a/src/Traits/ModelTrait.php
+++ b/src/Traits/ModelTrait.php
@@ -177,7 +177,7 @@ trait ModelTrait
      *
      * @return array|null
      */
-    public function findAll(int $limit = 0, int $offset = 0)
+    public function findAll(int $limit = null, int $offset = 0)
     {
         $data = parent::findAll($limit, $offset);
 


### PR DESCRIPTION
After upgrade to Codeigniter version 4.5 it broken while using the ModelTrait look like Codeigniter changed thier findAll() method.

i update `$limit = 0` to `$limit = null` 

CI4 now use null as default value to limit instead of 0

<img width="1361" alt="Screenshot 2024-04-24 at 7 42 38 AM" src="https://github.com/tattersoftware/codeigniter4-relations/assets/38796424/fcc7c111-9fb3-4dc9-a5c1-ee66e83113b5">
